### PR TITLE
Add glm-chaiscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [QtChaiScript](https://github.com/facontidavide/QtChaiScript) - ChaiScript bindings to Qt
 - [ChaiScript_Extras_Box2D](https://github.com/RobLoach/ChaiScript_Extras_Box2D) - ChaiScript bindings to [Box2D](https://github.com/erincatto/Box2D)
 - [ChaiScript_Extras_Liquidfun](https://github.com/Alia5/ChaiScript_Extras_Liquidfun) - ChaiScript bindings to [Liquidfun](https://github.com/google/liquidfun)
+- [glm-chaiscript](https://github.com/Ybalrid/chaiscript-glm) - ChaiScript bindings to [GLM - OpenGL Mathematics](https://github.com/g-truc/glm)
 
 ## Resources
 


### PR DESCRIPTION
I found it super strange that nobody made bindings to glm publicly available, so I started working on these one. For now the principal functions for 3D vectors and quaternions are in, and the many other missing types are coming. I just started with what is the most useful to expose for my use-case (scripting for video game objects, with vector representing position, scale, euler angles and quaternion for absolute rotation/orientation)

As it is the goal of GLM anyway : function and type names mimic the ones of the GLSL language, the bindings are done without the "glm" namespace, so in chaiscript it will look like this : 

```chaiscript
var v = vec3(1.0, 2.0, 3.0);
```

Each defined type provide a "to_string" overload for chaiscript to use with "print"